### PR TITLE
Add Unix support

### DIFF
--- a/src/main/java/com/oldhu/suunto2nike/Util.java
+++ b/src/main/java/com/oldhu/suunto2nike/Util.java
@@ -77,6 +77,11 @@ public class Util
 		return (OS.indexOf("mac") >= 0);
 	}
 
+	public static boolean isUnix() {
+		String OS = System.getProperty("os.name").toLowerCase();
+		return (OS.indexOf("nix") >= 0 || OS.indexOf("nux") >= 0 || OS.indexOf("aix") > 0 );
+	}
+
 	public static Element appendElement(Node parent, String name)
 	{
 		return appendElement(parent, name, null);
@@ -123,6 +128,10 @@ public class Util
 		if (Util.isMac()) {
 			String userHome = System.getProperty("user.home");
 			return new File(new File(userHome), "Library/Application Support/Suunto/");
+		}
+		if (Util.isUnix()) {
+			String userHome = System.getProperty("user.home");
+			return new File(new File(userHome), "Suunto");
 		}
 		return null;
 	}


### PR DESCRIPTION
MovesLink folder is set to $HOME/Suunto

I wanted to pass the folder as command line argument, but it wasn't possible in the Util.java file. If you have a better idea I will update my merge request.

One more thing - since it's UNIX, this folder name could be OK if the user creates a symbolic link with that name to point at the real location.